### PR TITLE
docs: add install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ This repository contains types for CloudEvents issued by Google.
 
 - Node 10 (or higher)
 
+## Install
+
+```sh
+npm i @google/events
+```
+
+## Examples
+
+- [TypeScript examples](./examples/typescript.ts)
+
 ## Generate
 
 Generate libraries:


### PR DESCRIPTION
Adds simple install instructions and a link to TS examples. (Current JS samples a blocked by protoc. We should probably move to quicktype.)

Fixes: https://github.com/googleapis/google-cloudevents-nodejs/issues/13