### PR TITLE
fix: compile before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "echo 'no tests'",
     "compile": "tsc",
+    "prepare": "npm run compile",
     "pretest": "npm run compile"
   },
   "repository": "googleapis/google-cloudevents-nodejs",


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloudevents-nodejs/issues/19.