### PR TITLE
ci: use standard release please files

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,2 +1,0 @@
-releaseType: node
-handleGHRelease: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,7 +2,7 @@
 on:
   push:
     branches:
-      - main
+      - master
 name: release-please
 jobs:
   release-please:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,11 +22,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: 'https://wombat-dressing-room.appspot.com'
         if: ${{ steps.release.outputs.release_created }}
       - run: npm ci
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.CLOUDEVENTS_NPM_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,32 @@
+# https://github.com/GoogleCloudPlatform/release-please-action
+on:
+  push:
+    branches:
+      - main
+name: release-please
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: GoogleCloudPlatform/release-please-action@v1.6.3
+        id: release
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: node
+          package-name: test-release-please
+      # The logic below handles the npm publication:
+      - uses: actions/checkout@v2
+        # these if statements ensure that a publication only occurs when
+        # a new release is created:
+        if: ${{ steps.release.outputs.release_created }}
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: 'https://registry.npmjs.org'
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm ci
+        if: ${{ steps.release.outputs.release_created }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
- Uses normal release-please action via a workflow (https://github.com/GoogleCloudPlatform/release-please-action)
  - Other release-please setup didn't create a release PR after merging https://github.com/googleapis/google-cloudevents-nodejs/pull/29
    - Not sure what happened. I don't think I can manually trigger a PR.
  - Other release-please setup isn't documented.
    - This setup seems to work as tested here: https://github.com/grant/release-please-test