### PR TITLE
docs: update samples to use actual events objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ The steps are:
 From [JavaScript example](./examples/javascript.js).
 
 ```js
-const {toMessagePublishedData} = require('@google/events/cloud/pubsub/v1');
+const {toMessagePublishedEvent} = require('@google/events/cloud/pubsub/v1/MessagePublishedData');
 
+/**
+ * A Pub/Sub message as an object, for example what you'd see from a POST request.
+ */
 const obj = {
     message: {
         data: Buffer.from('Pub/Sub data').toString('base64'),
@@ -42,8 +45,7 @@ const obj = {
     subscription: 'projects/my-project/subscriptions/cre-us-central1-pubsub-trigger-5-sub-000'
 };
 
-// JavaScript example (cast to type)
-const jsExample = toMessagePublishedData(obj);
+const jsExample = toMessagePublishedEvent(obj);
 console.log(jsExample.message.data);
 ```
 
@@ -63,8 +65,11 @@ The steps are:
 From [TypeScript example](./examples/typescript.ts):
 
 ```ts
-import {MessagePublishedData} from '@google/events/cloud/pubsub/v1';
+import {MessagePublishedEvent} from '@google/events/cloud/pubsub/v1/MessagePublishedData';
 
+/**
+ * A Pub/Sub message as an object, for example what you'd see from a POST request.
+ */
 const obj = {
     message: {
         data: atob('Pub/Sub data'),
@@ -74,8 +79,8 @@ const obj = {
     subscription: 'projects/my-project/subscriptions/cre-us-central1-pubsub-trigger-5-sub-000'
 };
 
-const tsExample: MessagePublishedData = obj;
-console.log(tsExample.message.messageId);
+const tsExample: MessagePublishedEvent = obj;
+console.log(tsExample.message.data);
 ```
 
 ---

--- a/examples/javascript.js
+++ b/examples/javascript.js
@@ -1,4 +1,4 @@
-const {toMessagePublishedData} = require('@google/events/cloud/pubsub/v1');
+const {toMessagePublishedEvent} = require('@google/events/cloud/pubsub/v1/MessagePublishedData');
 
 /**
  * A Pub/Sub message as an object, for example what you'd see from a POST request.
@@ -12,5 +12,5 @@ const obj = {
     subscription: 'projects/my-project/subscriptions/cre-us-central1-pubsub-trigger-5-sub-000'
 };
 
-const jsExample = toMessagePublishedData(obj);
+const jsExample = toMessagePublishedEvent(obj);
 console.log(jsExample.message.data);

--- a/examples/typescript.ts
+++ b/examples/typescript.ts
@@ -1,4 +1,4 @@
-import {MessagePublishedData} from '@google/events/cloud/pubsub/v1';
+import {MessagePublishedEvent} from '@google/events/cloud/pubsub/v1/MessagePublishedData';
 
 /**
  * A Pub/Sub message as an object, for example what you'd see from a POST request.
@@ -12,5 +12,5 @@ const obj = {
     subscription: 'projects/my-project/subscriptions/cre-us-central1-pubsub-trigger-5-sub-000'
 };
 
-const tsExample: MessagePublishedData = obj;
-console.log(tsExample.message.messageId);
+const tsExample: MessagePublishedEvent = obj;
+console.log(tsExample.message.data);


### PR DESCRIPTION
Updates the doc samples to use the actual event library.

Fixes some small typos.

There's an upstream error in the schema with message IDs filed here:
https://github.com/googleapis/google-cloudevents/issues/64