### PR TITLE
feat: rework the gen and postgen setup with separate jsonschema dir

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -10,28 +10,17 @@ https://github.com/googleapis/google-cloudevents
 
 To generate this library, follow these steps:
 
-- Install `qt` globally from https://github.com/googleapis/google-cloudevents/tree/master/tools/quicktype-wrapper
-- Clone the source repo: `git clone git@github.com:googleapis/google-cloudevents.git`
+### Setup
+
+- Install the `qt` CLI globally from https://github.com/googleapis/google-cloudevents/tree/master/tools/quicktype-wrapper
+- Clone the types source repo: `git clone git@github.com:googleapis/google-cloudevents.git`
 - Clone this language repo: `git clone git@github.com:googleapis/google-cloudevents-nodejs.git --depth 1`
-- In the root of this Node repo, run the following:
-  - ```sh
-    qt \
-    --in=$(dirname $PWD)/google-cloudevents/proto \
-    --out=$PWD \
-    --l=typescript
-    ```
-  - This generates a `google/` folder.
-- Run: `cp -r google/events/cloud . && rm -rf google/`
-  - This simplifies the output directory structure of our Google Event schemas.
-- Run: `npm run postgen`
-  - This polishes the generated Quicktype output in TypeScript.
-- Run: `npm run build`
-  - This compiles the TypeScript source.
+
+### Generate and Build
+
+- Generate: In the root of this Node repo, run the script: `npm run gen`. This generates this library from JSON schemas.
+- Build: In the root of this repo, run the script: `npm run build`. This compiles the TypeScript source.
 - Your package should be ready to publish.
-
----
-
-If at any point you want to restart the generation process, just delete `google/` and `cloud/` folders.
 
 ## Publish to npm
 

--- a/cloud/audit/v1/LogEntryData.ts
+++ b/cloud/audit/v1/LogEntryData.ts
@@ -7,76 +7,261 @@
 // These functions will throw an error if the JSON doesn't
 // match the expected interface, even if the JSON is valid.
 
-export interface LogEntryDataObject {
-    /**
-     * This event is triggered when a new audit log entry is written.
-     */
-    AuditLogWrittenEvent?: AuditLogWrittenEvent;
-}
-
 /**
  * This event is triggered when a new audit log entry is written.
  */
-export interface AuditLogWrittenEvent {
-    insert_id?:         string;
-    labels?:            { [key: string]: any };
-    log_name?:          string;
-    operation?:         LogEntryOperation;
-    proto_payload?:     AuditLog;
+export interface LogEntryData {
+    /**
+     * A unique identifier for the log entry.
+     */
+    insert_id?: string;
+    /**
+     * A set of user-defined (key, value) data that provides additional information about the
+     * log entry.
+     */
+    labels?: { [key: string]: any };
+    /**
+     * The resource name of the log to which this log entry belongs.
+     */
+    log_name?: string;
+    /**
+     * Information about an operation associated with the log entry, if applicable.
+     */
+    operation?: LogEntryOperation;
+    /**
+     * The log entry payload, which is always an AuditLog for Cloud Audit Log events.
+     */
+    proto_payload?: AuditLog;
+    /**
+     * The time the log entry was received by Logging.
+     */
     receive_timestamp?: string;
-    resource?:          MonitoredResource;
-    severity?:          number;
-    span_id?:           string;
-    timestamp?:         string;
-    trace?:             string;
+    /**
+     * The monitored resource that produced this log entry. Example: a log entry that reports a
+     * database error would be associated with the monitored resource designating the particular
+     * database that reported the error.
+     */
+    resource?: MonitoredResource;
+    /**
+     * The severity of the log entry.
+     */
+    severity?: string;
+    /**
+     * The span ID within the trace associated with the log entry, if any. For Trace spans, this
+     * is the same format that the Trace API v2 uses: a 16-character hexadecimal encoding of an
+     * 8-byte array, such as `000000000000004a`.
+     */
+    span_id?: string;
+    /**
+     * The time the event described by the log entry occurred.
+     */
+    timestamp?: string;
+    /**
+     * Resource name of the trace associated with the log entry, if any. If it contains a
+     * relative resource name, the name is assumed to be relative to `//tracing.googleapis.com`.
+     * Example: `projects/my-projectid/traces/06796866738c859f2f19b7cfb3214824`
+     */
+    trace?: string;
 }
 
+/**
+ * Information about an operation associated with the log entry, if applicable.
+ *
+ * Additional information about a potentially long-running operation with which a log entry
+ * is associated.
+ */
 export interface LogEntryOperation {
-    first?:    boolean;
-    id?:       string;
-    last?:     boolean;
+    /**
+     * True if this is the first log entry in the operation.
+     */
+    first?: boolean;
+    /**
+     * An arbitrary operation identifier. Log entries with the same identifier are assumed to be
+     * part of the same operation.
+     */
+    id?: string;
+    /**
+     * True if this is the last log entry in the operation.
+     */
+    last?: boolean;
+    /**
+     * An arbitrary producer identifier. The combination of `id` and `producer` must be globally
+     * unique. Examples for `producer`: `"MyDivision.MyBigCompany.com"`,
+     * `"github.com/MyProject/MyApplication"`.
+     */
     producer?: string;
 }
 
+/**
+ * The log entry payload, which is always an AuditLog for Cloud Audit Log events.
+ */
 export interface AuditLog {
-    authentication_info?:     AuthenticationInfo;
-    authorization_info?:      AuthorizationInfo[];
-    metadata?:                { [key: string]: any };
-    method_name?:             string;
-    num_response_items?:      number;
-    request?:                 { [key: string]: any };
-    request_metadata?:        RequestMetadata;
-    resource_location?:       ResourceLocation;
-    resource_name?:           string;
+    /**
+     * Authentication information.
+     */
+    authentication_info?: AuthenticationInfo;
+    /**
+     * Authorization information. If there are multiple resources or permissions involved, then
+     * there is one AuthorizationInfo element for each {resource, permission} tuple.
+     */
+    authorization_info?: AuthorizationInfo[];
+    /**
+     * Other service-specific data about the request, response, and other information associated
+     * with the current audited event.
+     */
+    metadata?: { [key: string]: any };
+    /**
+     * The name of the service method or operation. For example
+     * "google.datastore.v1.Datastore.RunQuery"
+     */
+    method_name?: string;
+    /**
+     * The number of items returned from a List or Query API method, if applicable.
+     */
+    num_response_items?: number;
+    /**
+     * The operation request. This may not include all request parameters, such as those that
+     * are too large, privacy-sensitive, or duplicated elsewhere in the log record. It should
+     * never include user-generated data, such as file contents. When the JSON object
+     * represented here has a proto equivalent, the proto name will be indicated in the `@type`
+     * property.
+     */
+    request?: { [key: string]: any };
+    /**
+     * Metadata about the operation.
+     */
+    request_metadata?: RequestMetadata;
+    /**
+     * The resource location information.
+     */
+    resource_location?: ResourceLocation;
+    /**
+     * The resource or collection that is the target of the operation. For example
+     * "shelves/SHELF_ID/books"
+     */
+    resource_name?: string;
+    /**
+     * The resource's original state before mutation.
+     */
     resource_original_state?: { [key: string]: any };
-    response?:                { [key: string]: any };
-    service_data?:            { [key: string]: any };
-    service_name?:            string;
-    status?:                  Status;
+    /**
+     * The operation response. This may not include all response elements, such as those that
+     * are too large, privacy-sensitive, or duplicated elsewhere in the log record. It should
+     * never include user-generated data, such as file contents. When the JSON object
+     * represented here has a proto equivalent, the proto name will be indicated in the `@type`
+     * property.
+     */
+    response?: { [key: string]: any };
+    /**
+     * Deprecated, use `metadata` field instead. Other service-specific data about the request,
+     * response, and other activities. When the JSON object represented here has a proto
+     * equivalent, the proto name will be indicated in the `@type` property.
+     */
+    service_data?: { [key: string]: any };
+    /**
+     * The name of the API service performing the operation. For example,
+     * `"datastore.googleapis.com"`.
+     */
+    service_name?: string;
+    /**
+     * The status of the overall operation.
+     */
+    status?: Status;
 }
 
+/**
+ * Authentication information.
+ *
+ * Authentication information for the operation.
+ */
 export interface AuthenticationInfo {
-    authority_selector?:              string;
-    principal_email?:                 string;
-    principal_subject?:               string;
+    /**
+     * The authority selector specified by the requestor, if any. It is not guaranteed that the
+     * principal was allowed to use this authority.
+     */
+    authority_selector?: string;
+    /**
+     * The email address of the authenticated user (or service account on behalf of third party
+     * principal) making the request. For privacy reasons, the principal email address is
+     * redacted for all read-only operations that fail with a "permission denied" error.
+     */
+    principal_email?: string;
+    /**
+     * String representation of identity of requesting party. Populated for both first and third
+     * party identities.
+     */
+    principal_subject?: string;
+    /**
+     * Identity delegation history of an authenticated service account that makes the request.
+     * It contains information on the real authorities that try to access GCP resources by
+     * delegating on a service account. When multiple authorities present, they are guaranteed
+     * to be sorted based on the original ordering of the identity delegation events.
+     */
     service_account_delegation_info?: ServiceAccountDelegationInfo[];
-    service_account_key_name?:        string;
-    third_party_principal?:           { [key: string]: any };
+    /**
+     * The name of the service account key used to create or exchange credentials for
+     * authenticating the service account making the request. This is a scheme-less URI full
+     * resource name.
+     */
+    service_account_key_name?: string;
+    /**
+     * The third party identification (if any) of the authenticated user making the request.
+     * When the JSON object represented here has a proto equivalent, the proto name will be
+     * indicated in the @type property.
+     */
+    third_party_principal?: { [key: string]: any };
 }
 
+/**
+ * Identity delegation history of an authenticated service account
+ */
 export interface ServiceAccountDelegationInfo {
-    principal_email?:    string;
-    service_metadata?:   { [key: string]: any };
+    /**
+     * The email address of a Google account.
+     */
+    principal_email?: string;
+    /**
+     * Metadata about the service that uses the service account.
+     */
+    service_metadata?: { [key: string]: any };
+    /**
+     * Metadata about third party identity.
+     */
     third_party_claims?: { [key: string]: any };
 }
 
+/**
+ * Authorization information. If there are multiple resources or permissions involved, then
+ * there is one AuthorizationInfo element for each {resource, permission} tuple.
+ */
 export interface AuthorizationInfo {
-    granted?:             boolean;
-    permission?:          string;
-    resource?:            string;
+    /**
+     * Whether or not authorization for resource and permission was granted.
+     */
+    granted?: boolean;
+    /**
+     * The required IAM permission.
+     */
+    permission?: string;
+    /**
+     * The resource being accessed, as a REST-style string.
+     */
+    resource?: string;
+    /**
+     * Resource attributes used in IAM condition evaluation. This field contains resource
+     * attributes like resource type and resource name. To get the whole view of the attributes
+     * used in IAM condition evaluation, the user must also look into
+     * AuditLog.request_metadata.request_attributes.
+     */
     resource_attributes?: Resource;
 }
 
+/**
+ * Resource attributes used in IAM condition evaluation. This field contains resource
+ * attributes like resource type and resource name. To get the whole view of the attributes
+ * used in IAM condition evaluation, the user must also look into
+ * AuditLog.request_metadata.request_attributes.
+ */
 export interface Resource {
     labels?:  { [key: string]: any };
     name?:    string;
@@ -84,14 +269,43 @@ export interface Resource {
     type?:    string;
 }
 
+/**
+ * Metadata about the operation.
+ */
 export interface RequestMetadata {
-    caller_ip?:                  string;
-    caller_network?:             string;
+    /**
+     * The IP address of the caller. For caller from internet, this will be public IPv4 or IPv6
+     * address. For caller from a Compute Engine VM with external IP address, this will be the
+     * VM's external IP address. For caller from a Compute Engine VM without external IP
+     * address, if the VM is in the same organization (or project) as the accessed resource,
+     * `caller_ip` will be the VM's internal IPv4 address, otherwise the `caller_ip` will be
+     * redacted to "gce-internal-ip". See https://cloud.google.com/compute/docs/vpc/ for more
+     * information."
+     */
+    caller_ip?: string;
+    /**
+     * The network of the caller.
+     */
+    caller_network?: string;
+    /**
+     * The user agent of the caller. This information is not authenticated and should be treated
+     * accordingly.
+     */
     caller_supplied_user_agent?: string;
-    destination_attributes?:     Peer;
-    request_attributes?:         Request;
+    /**
+     * The destination of a network activity, such as accepting a TCP connection.
+     */
+    destination_attributes?: Peer;
+    /**
+     * Request attributes used in IAM condition evaluation. This field contains request
+     * attributes like request time and access levels associated with the request.
+     */
+    request_attributes?: Request;
 }
 
+/**
+ * The destination of a network activity, such as accepting a TCP connection.
+ */
 export interface Peer {
     ip?:          string;
     labels?:      { [key: string]: any };
@@ -100,6 +314,10 @@ export interface Peer {
     region_code?: string;
 }
 
+/**
+ * Request attributes used in IAM condition evaluation. This field contains request
+ * attributes like request time and access levels associated with the request.
+ */
 export interface Request {
     auth?:     Auth;
     headers?:  { [key: string]: any };
@@ -123,31 +341,77 @@ export interface Auth {
     principal?:     string;
 }
 
+/**
+ * The resource location information.
+ *
+ * Location information about a resource.
+ */
 export interface ResourceLocation {
-    current_locations?:  string[];
+    /**
+     * The locations of a resource after the execution of the operation. Requests to create or
+     * delete a location based resource must populate the 'current_locations' field and not the
+     * 'original_locations' field.
+     */
+    current_locations?: string[];
+    /**
+     * The locations of a resource prior to the execution of the operation. Requests that mutate
+     * the resource's location must populate both the 'original_locations' as well as the
+     * 'current_locations' fields. For example:
+     */
     original_locations?: string[];
 }
 
+/**
+ * The status of the overall operation.
+ */
 export interface Status {
-    code?:    number;
+    /**
+     * The status code, which should be an enum value of [google.rpc.Code][google.rpc.Code].
+     */
+    code?: number;
+    /**
+     * A list of messages that carry the error details.  There is a common set of message types
+     * for APIs to use.
+     */
     details?: any;
+    /**
+     * A developer-facing error message, which should be in English. Any user-facing error
+     * message should be localized and sent in the
+     * [google.rpc.Status.details][google.rpc.Status.details] field, or localized by the client.
+     */
     message?: string;
 }
 
+/**
+ * The monitored resource that produced this log entry. Example: a log entry that reports a
+ * database error would be associated with the monitored resource designating the particular
+ * database that reported the error.
+ *
+ * The monitored resource that produced this log entry.
+ */
 export interface MonitoredResource {
+    /**
+     * Values for all of the labels listed in the associated monitored resource descriptor. For
+     * example, Compute Engine VM instances use the labels `"project_id"`, `"instance_id"`, and
+     * `"zone"`.
+     */
     labels?: { [key: string]: any };
-    type?:   string;
+    /**
+     * Required. The monitored resource type. For example, the type of a Compute Engine VM
+     * instance is `gce_instance`.
+     */
+    type?: string;
 }
 
 // Converts JSON strings to/from your types
 // and asserts the results of JSON.parse at runtime
 export class Convert {
-    public static toLogEntryData(json: string): any[] | boolean | number | number | null | LogEntryDataObject | string {
-        return cast(JSON.parse(json), u(a("any"), true, 3.14, 0, null, r("LogEntryDataObject"), ""));
+    public static toLogEntryData(json: string): LogEntryData {
+        return cast(JSON.parse(json), r("LogEntryData"));
     }
 
-    public static logEntryDataToJson(value: any[] | boolean | number | number | null | LogEntryDataObject | string): string {
-        return JSON.stringify(uncast(value, u(a("any"), true, 3.14, 0, null, r("LogEntryDataObject"), "")), null, 2);
+    public static logEntryDataToJson(value: LogEntryData): string {
+        return JSON.stringify(uncast(value, r("LogEntryData")), null, 2);
     }
 }
 
@@ -284,10 +548,7 @@ function r(name: string) {
 }
 
 const typeMap: any = {
-    "LogEntryDataObject": o([
-        { json: "AuditLogWrittenEvent", js: "AuditLogWrittenEvent", typ: u(undefined, r("AuditLogWrittenEvent")) },
-    ], "any"),
-    "AuditLogWrittenEvent": o([
+    "LogEntryData": o([
         { json: "insert_id", js: "insert_id", typ: u(undefined, "") },
         { json: "labels", js: "labels", typ: u(undefined, m("any")) },
         { json: "log_name", js: "log_name", typ: u(undefined, "") },
@@ -295,7 +556,7 @@ const typeMap: any = {
         { json: "proto_payload", js: "proto_payload", typ: u(undefined, r("AuditLog")) },
         { json: "receive_timestamp", js: "receive_timestamp", typ: u(undefined, "") },
         { json: "resource", js: "resource", typ: u(undefined, r("MonitoredResource")) },
-        { json: "severity", js: "severity", typ: u(undefined, 0) },
+        { json: "severity", js: "severity", typ: u(undefined, "") },
         { json: "span_id", js: "span_id", typ: u(undefined, "") },
         { json: "timestamp", js: "timestamp", typ: u(undefined, "") },
         { json: "trace", js: "trace", typ: u(undefined, "") },
@@ -400,8 +661,8 @@ const typeMap: any = {
 /**
  * Cast a raw JSON object to a typed event (useful for IDE autocompletion).
  * @param {object} json The JSON object
- * @return {AuditLogWrittenEvent} The object with type annotations
+ * @return {LogEntryData} The object with type annotations
  */
-export const toAuditLogWrittenEvent = (json: object) => {
-  return json as AuditLogWrittenEvent;
+export const toLogEntryData = (json: object) => {
+  return json as LogEntryData;
 };

--- a/cloud/pubsub/v1/MessagePublishedData.ts
+++ b/cloud/pubsub/v1/MessagePublishedData.ts
@@ -7,36 +7,55 @@
 // These functions will throw an error if the JSON doesn't
 // match the expected interface, even if the JSON is valid.
 
-export interface MessagePublishedDataObject {
-    /**
-     * This event is triggered when a Pub/Sub message is published.
-     */
-    MessagePublishedEvent?: MessagePublishedEvent;
-}
-
 /**
- * This event is triggered when a Pub/Sub message is published.
+ * A message that is published by publishers and consumed by subscribers.
  */
-export interface MessagePublishedEvent {
-    message?:      PubsubMessage;
+export interface MessagePublishedData {
+    /**
+     * The message that was published.
+     */
+    message?: PubsubMessage;
+    /**
+     * The resource name of the subscription for which this event was generated. The format of
+     * the value is `projects/{project-id}/subscriptions/{subscription-id}`.
+     */
     subscription?: string;
 }
 
+/**
+ * The message that was published.
+ *
+ * A message published to a topic.
+ */
 export interface PubsubMessage {
+    /**
+     * Attributes for this message. If this field is empty, the message must contain non-empty
+     * data. This can be used to filter messages on the subscription.
+     */
     attributes?: { [key: string]: any };
-    data?:       string;
-    messageId?:  string;
+    /**
+     * The message data field. If this field is empty, the message must contain at least one
+     * attribute. A base64-encoded string.
+     */
+    data?: string;
+    /**
+     * ID of this message, assigned by the server when the message is published. Guaranteed to
+     * be unique within the topic. This value may be read by a subscriber that receives a
+     * PubsubMessage via a subscriptions.pull call or a push delivery. It must not be populated
+     * by the publisher in a topics.publish call.
+     */
+    messageId?: string;
 }
 
 // Converts JSON strings to/from your types
 // and asserts the results of JSON.parse at runtime
 export class Convert {
-    public static toMessagePublishedData(json: string): any[] | boolean | number | number | null | MessagePublishedDataObject | string {
-        return cast(JSON.parse(json), u(a("any"), true, 3.14, 0, null, r("MessagePublishedDataObject"), ""));
+    public static toMessagePublishedData(json: string): MessagePublishedData {
+        return cast(JSON.parse(json), r("MessagePublishedData"));
     }
 
-    public static messagePublishedDataToJson(value: any[] | boolean | number | number | null | MessagePublishedDataObject | string): string {
-        return JSON.stringify(uncast(value, u(a("any"), true, 3.14, 0, null, r("MessagePublishedDataObject"), "")), null, 2);
+    public static messagePublishedDataToJson(value: MessagePublishedData): string {
+        return JSON.stringify(uncast(value, r("MessagePublishedData")), null, 2);
     }
 }
 
@@ -173,10 +192,7 @@ function r(name: string) {
 }
 
 const typeMap: any = {
-    "MessagePublishedDataObject": o([
-        { json: "MessagePublishedEvent", js: "MessagePublishedEvent", typ: u(undefined, r("MessagePublishedEvent")) },
-    ], "any"),
-    "MessagePublishedEvent": o([
+    "MessagePublishedData": o([
         { json: "message", js: "message", typ: u(undefined, r("PubsubMessage")) },
         { json: "subscription", js: "subscription", typ: u(undefined, "") },
     ], "any"),
@@ -190,8 +206,8 @@ const typeMap: any = {
 /**
  * Cast a raw JSON object to a typed event (useful for IDE autocompletion).
  * @param {object} json The JSON object
- * @return {MessagePublishedEvent} The object with type annotations
+ * @return {MessagePublishedData} The object with type annotations
  */
-export const toMessagePublishedEvent = (json: object) => {
-  return json as MessagePublishedEvent;
+export const toMessagePublishedData = (json: object) => {
+  return json as MessagePublishedData;
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "gts clean",
     "build": "tsc --skipLibCheck",
     "watch": "tsc --watch --skipLibCheck",
-    "postgen": "node tools/postgen.js"
+    "gen": "./tools/gen.sh && node tools/postgen.js"
   },
   "repository": "googleapis/google-cloudevents-nodejs",
   "author": "Google Inc.",

--- a/tools/gen.sh
+++ b/tools/gen.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+qt \
+--in=$(dirname $PWD)/google-cloudevents/jsonschema \
+--out=$PWD \
+--l=typescript

--- a/tools/gen.sh
+++ b/tools/gen.sh
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Copyright 2020 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 
 qt \

--- a/tools/postgen.ts
+++ b/tools/postgen.ts
@@ -33,25 +33,25 @@ const recursive = require("recursive-readdir");
     console.log(`- Fixing: ${filename}`);
     const typeFileContent = fs.readFileSync(filename).toString();
 
-    // Get 2nd interface
+    // Get TS interfaces
     const lines = typeFileContent.split('\n');
     const interfaceLines = lines.filter((line) => {
       return line.startsWith('export interface');
     });
 
-    // The data name, e.g. 'export interface AuditLogWrittenEvent {'
-    const dataEventName = interfaceLines[1]
+    // The data name, e.g. 'export interface MessagePublishedData {'
+    const dataName = interfaceLines[0]
         .split(' ')
-        .filter((token) => token.endsWith('Event'))[0];
+        .filter((token) => token.endsWith('Data'))[0];
 
     const newTypeFileContent = typeFileContent + `
 /**
  * Cast a raw JSON object to a typed event (useful for IDE autocompletion).
  * @param {object} json The JSON object
- * @return {${dataEventName}} The object with type annotations
+ * @return {${dataName}} The object with type annotations
  */
-export const to${dataEventName} = (json: object) => {
-  return json as ${dataEventName};
+export const to${dataName} = (json: object) => {
+  return json as ${dataName};
 };`;
     // Write the updated file back
     fs.writeFileSync(filename, newTypeFileContent);


### PR DESCRIPTION
Updates gen/postgen steps now that jsonschemas are in a separate directory.

- Re-gens library (you'll notice more comments now)
- Uses unwrapped event object – i.e. just the `CloudEvent#data` which is our HTTP POST body
- Simplifies setup steps and generation process (gen and postgen combined). 1 step now - `npm run gen`.

Should be ready for integration with the samples.

CC: @jskeet @michaelawyu 