### PR TITLE
docs: add note about autogeneration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This repository contains types for CloudEvents issued by Google,
 enabling you to have autocompletion in **JavaScript** or **TypeScript** projects.
 
+> Note: This repo is auto-generated from schemas in https://github.com/googleapis/google-cloudevents
+
 ## Prerequisites
 
 - Node 10+


### PR DESCRIPTION
Adds a minimal note that this library is autogenerated.

Addresses part of https://github.com/googleapis/google-cloudevents-nodejs/issues/51

## Preview

> Note: This repo is auto-generated from schemas in https://github.com/googleapis/google-cloudevents
