### PR TITLE
feat: run the generator, 11/2020

### DIFF
--- a/cloud/audit/v1/LogEntryData.ts
+++ b/cloud/audit/v1/LogEntryData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * Generic log entry, used as a wrapper for Cloud Audit Logs in events.

--- a/cloud/cloudbuild/v1/BuildEventData.ts
+++ b/cloud/cloudbuild/v1/BuildEventData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * Build event data
@@ -142,7 +144,7 @@ export interface BuildEventData {
      * If the build does not specify source or images,
      * these keys will not be included.
      */
-    timing?: { [key: string]: { [key: string]: any } };
+    timing?: { [key: string]: GoogleEventsCloudCloudbuildV1TimeSpan };
 }
 
 /**
@@ -208,7 +210,23 @@ export interface Objects {
     /**
      * Stores timing information for pushing all artifact objects.
      */
-    timing?: { [key: string]: any };
+    timing?: ObjectsTiming;
+}
+
+/**
+ * Stores timing information for pushing all artifact objects.
+ *
+ * Start and end times for a build execution phase.
+ */
+export interface ObjectsTiming {
+    /**
+     * End of time span.
+     */
+    endTime?: Date;
+    /**
+     * Start of time span.
+     */
+    startTime?: Date;
 }
 
 /**
@@ -278,7 +296,7 @@ export interface Options {
      * Using a global volume in a build with only one step is not valid as
      * it is indicative of a build request with an incorrect configuration.
      */
-    volumes?: any[];
+    volumes?: GoogleEventsCloudCloudbuildV1Volume[];
     /**
      * Option to specify a `WorkerPool` for the build.
      * Format: projects/{project}/locations/{location}/workerPools/{workerPool}
@@ -312,6 +330,27 @@ export enum RequestedVerifyOptionEnum {
 export enum SubstitutionOptionEnum {
     AllowLoose = "ALLOW_LOOSE",
     MustMatch = "MUST_MATCH",
+}
+
+/**
+ * Volume describes a Docker container volume which is mounted into build steps
+ * in order to persist files across build step execution.
+ */
+export interface GoogleEventsCloudCloudbuildV1Volume {
+    /**
+     * Name of the volume to mount.
+     *
+     * Volume names must be unique per build step and must be valid names for
+     * Docker volumes. Each named volume must be used by at least two build steps.
+     */
+    name?: string;
+    /**
+     * Path at which to mount the volume.
+     *
+     * Paths must be absolute and cannot conflict with other volume paths on the
+     * same build step or with certain reserved volume paths.
+     */
+    path?: string;
 }
 
 /**
@@ -350,7 +389,7 @@ export interface Results {
     /**
      * Time to push all non-container artifacts.
      */
-    artifactTiming?: { [key: string]: any };
+    artifactTiming?: ArtifactTiming;
     /**
      * List of build step digests, in the order corresponding to build step
      * indices.
@@ -376,6 +415,24 @@ export interface Results {
 }
 
 /**
+ * Time to push all non-container artifacts.
+ *
+ * Stores timing information for pushing all artifact objects.
+ *
+ * Start and end times for a build execution phase.
+ */
+export interface ArtifactTiming {
+    /**
+     * End of time span.
+     */
+    endTime?: Date;
+    /**
+     * Start of time span.
+     */
+    startTime?: Date;
+}
+
+/**
  * An image built by the pipeline.
  */
 export interface Image {
@@ -391,7 +448,25 @@ export interface Image {
     /**
      * Stores timing information for pushing the specified image.
      */
-    pushTiming?: { [key: string]: any };
+    pushTiming?: PushTiming;
+}
+
+/**
+ * Stores timing information for pushing the specified image.
+ *
+ * Stores timing information for pushing all artifact objects.
+ *
+ * Start and end times for a build execution phase.
+ */
+export interface PushTiming {
+    /**
+     * End of time span.
+     */
+    endTime?: Date;
+    /**
+     * Start of time span.
+     */
+    startTime?: Date;
 }
 
 /**
@@ -422,11 +497,86 @@ export interface Source {
      * If provided, get the source from this location in a Cloud Source
      * Repository.
      */
-    repoSource?: { [key: string]: any };
+    repoSource?: RepoSource;
     /**
      * If provided, get the source from this location in Google Cloud Storage.
      */
-    storageSource?: { [key: string]: any };
+    storageSource?: StorageSource;
+}
+
+/**
+ * If provided, get the source from this location in a Cloud Source
+ * Repository.
+ *
+ * Location of the source in a Google Cloud Source Repository.
+ */
+export interface RepoSource {
+    /**
+     * Regex matching branches to build.
+     *
+     * The syntax of the regular expressions accepted is the syntax accepted by
+     * RE2 and described at https://github.com/google/re2/wiki/Syntax
+     */
+    branchName?: string;
+    /**
+     * Explicit commit SHA to build.
+     */
+    commitSha?: string;
+    /**
+     * Directory, relative to the source root, in which to run the build.
+     *
+     * This must be a relative path. If a step's `dir` is specified and is an
+     * absolute path, this value is ignored for that step's execution.
+     */
+    dir?: string;
+    /**
+     * Only trigger a build if the revision regex does NOT match the revision
+     * regex.
+     */
+    invertRegex?: boolean;
+    /**
+     * ID of the project that owns the Cloud Source Repository.
+     */
+    projectId?: string;
+    /**
+     * Name of the Cloud Source Repository.
+     */
+    repoName?: string;
+    /**
+     * Substitutions to use in a triggered build.
+     * Should only be used with RunBuildTrigger
+     */
+    substitutions?: { [key: string]: string };
+    /**
+     * Regex matching tags to build.
+     *
+     * The syntax of the regular expressions accepted is the syntax accepted by
+     * RE2 and described at https://github.com/google/re2/wiki/Syntax
+     */
+    tagName?: string;
+}
+
+/**
+ * If provided, get the source from this location in Google Cloud Storage.
+ *
+ * Location of the source in an archive file in Google Cloud Storage.
+ */
+export interface StorageSource {
+    /**
+     * Google Cloud Storage bucket containing the source (see
+     * [Bucket Name
+     * Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+     */
+    bucket?: string;
+    /**
+     * Google Cloud Storage generation for the object. If the generation is
+     * omitted, the latest generation will be used.
+     */
+    generation?: number | string;
+    /**
+     * Google Cloud Storage object containing the source.
+     */
+    object?: string;
 }
 
 /**
@@ -450,12 +600,12 @@ export interface SourceProvenance {
      * A copy of the build's `source.repo_source`, if exists, with any
      * revisions resolved.
      */
-    resolvedRepoSource?: { [key: string]: any };
+    resolvedRepoSource?: ResolvedRepoSourceObject;
     /**
      * A copy of the build's `source.storage_source`, if exists, with any
      * generations resolved.
      */
-    resolvedStorageSource?: { [key: string]: any };
+    resolvedStorageSource?: ResolvedStorageSourceObject;
 }
 
 export interface FileHashValue {
@@ -483,6 +633,87 @@ export enum TypeEnum {
     Md5 = "MD5",
     None = "NONE",
     Sha256 = "SHA256",
+}
+
+/**
+ * A copy of the build's `source.repo_source`, if exists, with any
+ * revisions resolved.
+ *
+ * If provided, get the source from this location in a Cloud Source
+ * Repository.
+ *
+ * Location of the source in a Google Cloud Source Repository.
+ */
+export interface ResolvedRepoSourceObject {
+    /**
+     * Regex matching branches to build.
+     *
+     * The syntax of the regular expressions accepted is the syntax accepted by
+     * RE2 and described at https://github.com/google/re2/wiki/Syntax
+     */
+    branchName?: string;
+    /**
+     * Explicit commit SHA to build.
+     */
+    commitSha?: string;
+    /**
+     * Directory, relative to the source root, in which to run the build.
+     *
+     * This must be a relative path. If a step's `dir` is specified and is an
+     * absolute path, this value is ignored for that step's execution.
+     */
+    dir?: string;
+    /**
+     * Only trigger a build if the revision regex does NOT match the revision
+     * regex.
+     */
+    invertRegex?: boolean;
+    /**
+     * ID of the project that owns the Cloud Source Repository.
+     */
+    projectId?: string;
+    /**
+     * Name of the Cloud Source Repository.
+     */
+    repoName?: string;
+    /**
+     * Substitutions to use in a triggered build.
+     * Should only be used with RunBuildTrigger
+     */
+    substitutions?: { [key: string]: string };
+    /**
+     * Regex matching tags to build.
+     *
+     * The syntax of the regular expressions accepted is the syntax accepted by
+     * RE2 and described at https://github.com/google/re2/wiki/Syntax
+     */
+    tagName?: string;
+}
+
+/**
+ * A copy of the build's `source.storage_source`, if exists, with any
+ * generations resolved.
+ *
+ * If provided, get the source from this location in Google Cloud Storage.
+ *
+ * Location of the source in an archive file in Google Cloud Storage.
+ */
+export interface ResolvedStorageSourceObject {
+    /**
+     * Google Cloud Storage bucket containing the source (see
+     * [Bucket Name
+     * Requirements](https://cloud.google.com/storage/docs/bucket-naming#requirements)).
+     */
+    bucket?: string;
+    /**
+     * Google Cloud Storage generation for the object. If the generation is
+     * omitted, the latest generation will be used.
+     */
+    generation?: number | string;
+    /**
+     * Google Cloud Storage object containing the source.
+     */
+    object?: string;
 }
 
 export enum StatusEnum {
@@ -565,7 +796,7 @@ export interface Step {
      * Stores timing information for pulling this build step's
      * builder image only.
      */
-    pullTiming?: { [key: string]: any };
+    pullTiming?: PullTiming;
     /**
      * A list of environment variables which are encrypted using a Cloud Key
      * Management Service crypto key. These values must be specified in the
@@ -587,7 +818,7 @@ export interface Step {
     /**
      * Stores timing information for executing this build step.
      */
-    timing?: { [key: string]: any };
+    timing?: StepTiming;
     /**
      * List of volumes to mount into the build step.
      *
@@ -598,7 +829,7 @@ export interface Step {
      * Using a named volume in only one step is not valid as it is indicative
      * of a build request with an incorrect configuration.
      */
-    volumes?: any[];
+    volumes?: GoogleEventsCloudCloudbuildV1Volume[];
     /**
      * The ID(s) of the step(s) that this build step depends on.
      * This build step will not start until all the build steps in `wait_for`
@@ -607,6 +838,25 @@ export interface Step {
      * completed successfully.
      */
     waitFor?: string[];
+}
+
+/**
+ * Stores timing information for pulling this build step's
+ * builder image only.
+ *
+ * Stores timing information for pushing all artifact objects.
+ *
+ * Start and end times for a build execution phase.
+ */
+export interface PullTiming {
+    /**
+     * End of time span.
+     */
+    endTime?: Date;
+    /**
+     * Start of time span.
+     */
+    startTime?: Date;
 }
 
 /**
@@ -633,6 +883,24 @@ export interface StepTimeout {
 }
 
 /**
+ * Stores timing information for executing this build step.
+ *
+ * Stores timing information for pushing all artifact objects.
+ *
+ * Start and end times for a build execution phase.
+ */
+export interface StepTiming {
+    /**
+     * End of time span.
+     */
+    endTime?: Date;
+    /**
+     * Start of time span.
+     */
+    startTime?: Date;
+}
+
+/**
  * Amount of time that this build should be allowed to run, to second
  * granularity. If this amount of time elapses, work on the build will cease
  * and the build status will be `TIMEOUT`.
@@ -653,6 +921,22 @@ export interface BuildEventDataTimeout {
      * 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
      */
     seconds?: number | string;
+}
+
+/**
+ * Stores timing information for pushing all artifact objects.
+ *
+ * Start and end times for a build execution phase.
+ */
+export interface GoogleEventsCloudCloudbuildV1TimeSpan {
+    /**
+     * End of time span.
+     */
+    endTime?: Date;
+    /**
+     * Start of time span.
+     */
+    startTime?: Date;
 }
 
 /**

--- a/cloud/firestore/v1/DocumentEventData.ts
+++ b/cloud/firestore/v1/DocumentEventData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * The data within all Firestore document events.
@@ -20,7 +22,7 @@ export interface DocumentEventData {
      * A Document object containing a pre-operation document snapshot.
      * This is only populated for update and delete events.
      */
-    oldValue?: { [key: string]: any };
+    oldValue?: OldValue;
     /**
      * A DocumentMask object that lists changed fields.
      * This is only populated for update events.
@@ -30,7 +32,298 @@ export interface DocumentEventData {
      * A Document object containing a post-operation document snapshot.
      * This is not populated for delete events. (TODO: check this!)
      */
-    value?: { [key: string]: any };
+    value?: Value;
+}
+
+/**
+ * A Document object containing a pre-operation document snapshot.
+ * This is only populated for update and delete events.
+ *
+ * A Firestore document.
+ */
+export interface OldValue {
+    /**
+     * The time at which the document was created.
+     *
+     * This value increases monotonically when a document is deleted then
+     * recreated. It can also be compared to values from other documents and
+     * the `read_time` of a query.
+     */
+    createTime?: Date;
+    /**
+     * The document's fields.
+     *
+     * The map keys represent field names.
+     *
+     * A simple field name contains only characters `a` to `z`, `A` to `Z`,
+     * `0` to `9`, or `_`, and must not start with `0` to `9`. For example,
+     * `foo_bar_17`.
+     *
+     * Field names matching the regular expression `__.*__` are reserved. Reserved
+     * field names are forbidden except in certain documented contexts. The map
+     * keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be
+     * empty.
+     *
+     * Field paths may be used in other contexts to refer to structured fields
+     * defined here. For `map_value`, the field path is represented by the simple
+     * or quoted field names of the containing fields, delimited by `.`. For
+     * example, the structured field
+     * `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be
+     * represented by the field path `foo.x&y`.
+     *
+     * Within a field path, a quoted field name starts and ends with `` ` `` and
+     * may contain any character. Some characters, including `` ` ``, must be
+     * escaped using a `\`. For example, `` `x&y` `` represents `x&y` and
+     * `` `bak\`tik` `` represents `` bak`tik ``.
+     */
+    fields?: { [key: string]: OldValueField };
+    /**
+     * The resource name of the document, for example
+     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     */
+    name?: string;
+    /**
+     * The time at which the document was last changed.
+     *
+     * This value is initially set to the `create_time` then increases
+     * monotonically with each change to the document. It can also be
+     * compared to values from other documents and the `read_time` of a query.
+     */
+    updateTime?: Date;
+}
+
+/**
+ * A message that can hold any of the supported value types.
+ */
+export interface OldValueField {
+    /**
+     * An array value.
+     *
+     * Cannot directly contain another array value, though can contain an
+     * map which contains another array.
+     */
+    arrayValue?: ArrayValue;
+    /**
+     * A boolean value.
+     */
+    booleanValue?: boolean;
+    /**
+     * A bytes value.
+     *
+     * Must not exceed 1 MiB - 89 bytes.
+     * Only the first 1,500 bytes are considered by queries.
+     */
+    bytesValue?: string;
+    /**
+     * A double value.
+     */
+    doubleValue?: number;
+    /**
+     * A geo point value representing a point on the surface of Earth.
+     */
+    geoPointValue?: GeoPointValue;
+    /**
+     * An integer value.
+     */
+    integerValue?: number | string;
+    /**
+     * A map value.
+     */
+    mapValue?: MapValue;
+    /**
+     * A null value.
+     */
+    nullValue?: number | string;
+    /**
+     * A reference to a document. For example:
+     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     */
+    referenceValue?: string;
+    /**
+     * A string value.
+     *
+     * The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.
+     * Only the first 1,500 bytes of the UTF-8 representation are considered by
+     * queries.
+     */
+    stringValue?: string;
+    /**
+     * A timestamp value.
+     *
+     * Precise only to microseconds. When stored, any additional precision is
+     * rounded down.
+     */
+    timestampValue?: Date;
+}
+
+/**
+ * A message that can hold any of the supported value types.
+ */
+export interface MapValueField {
+    /**
+     * An array value.
+     *
+     * Cannot directly contain another array value, though can contain an
+     * map which contains another array.
+     */
+    arrayValue?: ArrayValue;
+    /**
+     * A boolean value.
+     */
+    booleanValue?: boolean;
+    /**
+     * A bytes value.
+     *
+     * Must not exceed 1 MiB - 89 bytes.
+     * Only the first 1,500 bytes are considered by queries.
+     */
+    bytesValue?: string;
+    /**
+     * A double value.
+     */
+    doubleValue?: number;
+    /**
+     * A geo point value representing a point on the surface of Earth.
+     */
+    geoPointValue?: GeoPointValue;
+    /**
+     * An integer value.
+     */
+    integerValue?: number | string;
+    /**
+     * A map value.
+     */
+    mapValue?: MapValue;
+    /**
+     * A null value.
+     */
+    nullValue?: number | string;
+    /**
+     * A reference to a document. For example:
+     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     */
+    referenceValue?: string;
+    /**
+     * A string value.
+     *
+     * The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.
+     * Only the first 1,500 bytes of the UTF-8 representation are considered by
+     * queries.
+     */
+    stringValue?: string;
+    /**
+     * A timestamp value.
+     *
+     * Precise only to microseconds. When stored, any additional precision is
+     * rounded down.
+     */
+    timestampValue?: Date;
+}
+
+/**
+ * A map value.
+ */
+export interface MapValue {
+    /**
+     * The map's fields.
+     *
+     * The map keys represent field names. Field names matching the regular
+     * expression `__.*__` are reserved. Reserved field names are forbidden except
+     * in certain documented contexts. The map keys, represented as UTF-8, must
+     * not exceed 1,500 bytes and cannot be empty.
+     */
+    fields?: { [key: string]: MapValueField };
+}
+
+/**
+ * A message that can hold any of the supported value types.
+ */
+export interface ValueElement {
+    /**
+     * An array value.
+     *
+     * Cannot directly contain another array value, though can contain an
+     * map which contains another array.
+     */
+    arrayValue?: ArrayValue;
+    /**
+     * A boolean value.
+     */
+    booleanValue?: boolean;
+    /**
+     * A bytes value.
+     *
+     * Must not exceed 1 MiB - 89 bytes.
+     * Only the first 1,500 bytes are considered by queries.
+     */
+    bytesValue?: string;
+    /**
+     * A double value.
+     */
+    doubleValue?: number;
+    /**
+     * A geo point value representing a point on the surface of Earth.
+     */
+    geoPointValue?: GeoPointValue;
+    /**
+     * An integer value.
+     */
+    integerValue?: number | string;
+    /**
+     * A map value.
+     */
+    mapValue?: MapValue;
+    /**
+     * A null value.
+     */
+    nullValue?: number | string;
+    /**
+     * A reference to a document. For example:
+     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     */
+    referenceValue?: string;
+    /**
+     * A string value.
+     *
+     * The string, represented as UTF-8, must not exceed 1 MiB - 89 bytes.
+     * Only the first 1,500 bytes of the UTF-8 representation are considered by
+     * queries.
+     */
+    stringValue?: string;
+    /**
+     * A timestamp value.
+     *
+     * Precise only to microseconds. When stored, any additional precision is
+     * rounded down.
+     */
+    timestampValue?: Date;
+}
+
+/**
+ * An array value.
+ *
+ * Cannot directly contain another array value, though can contain an
+ * map which contains another array.
+ */
+export interface ArrayValue {
+    /**
+     * Values in the array.
+     */
+    values?: ValueElement[];
+}
+
+/**
+ * A geo point value representing a point on the surface of Earth.
+ */
+export interface GeoPointValue {
+    /**
+     * The latitude in degrees. It must be in the range [-90.0, +90.0].
+     */
+    latitude?: number;
+    /**
+     * The longitude in degrees. It must be in the range [-180.0, +180.0].
+     */
+    longitude?: number;
 }
 
 /**
@@ -44,6 +337,66 @@ export interface UpdateMask {
      * for a field path syntax reference.
      */
     fieldPaths?: string[];
+}
+
+/**
+ * A Document object containing a post-operation document snapshot.
+ * This is not populated for delete events. (TODO: check this!)
+ *
+ * A Document object containing a pre-operation document snapshot.
+ * This is only populated for update and delete events.
+ *
+ * A Firestore document.
+ */
+export interface Value {
+    /**
+     * The time at which the document was created.
+     *
+     * This value increases monotonically when a document is deleted then
+     * recreated. It can also be compared to values from other documents and
+     * the `read_time` of a query.
+     */
+    createTime?: Date;
+    /**
+     * The document's fields.
+     *
+     * The map keys represent field names.
+     *
+     * A simple field name contains only characters `a` to `z`, `A` to `Z`,
+     * `0` to `9`, or `_`, and must not start with `0` to `9`. For example,
+     * `foo_bar_17`.
+     *
+     * Field names matching the regular expression `__.*__` are reserved. Reserved
+     * field names are forbidden except in certain documented contexts. The map
+     * keys, represented as UTF-8, must not exceed 1,500 bytes and cannot be
+     * empty.
+     *
+     * Field paths may be used in other contexts to refer to structured fields
+     * defined here. For `map_value`, the field path is represented by the simple
+     * or quoted field names of the containing fields, delimited by `.`. For
+     * example, the structured field
+     * `"foo" : { map_value: { "x&y" : { string_value: "hello" }}}` would be
+     * represented by the field path `foo.x&y`.
+     *
+     * Within a field path, a quoted field name starts and ends with `` ` `` and
+     * may contain any character. Some characters, including `` ` ``, must be
+     * escaped using a `\`. For example, `` `x&y` `` represents `x&y` and
+     * `` `bak\`tik` `` represents `` bak`tik ``.
+     */
+    fields?: { [key: string]: OldValueField };
+    /**
+     * The resource name of the document, for example
+     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     */
+    name?: string;
+    /**
+     * The time at which the document was last changed.
+     *
+     * This value is initially set to the `create_time` then increases
+     * monotonically with each change to the document. It can also be
+     * compared to values from other documents and the `read_time` of a query.
+     */
+    updateTime?: Date;
 }
 
 /**

--- a/cloud/pubsub/v1/MessagePublishedData.ts
+++ b/cloud/pubsub/v1/MessagePublishedData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * The data received in an event when a message is published to a topic.

--- a/cloud/scheduler/v1/SchedulerJobData.ts
+++ b/cloud/scheduler/v1/SchedulerJobData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * Scheduler job data.

--- a/cloud/storage/v1/StorageObjectData.ts
+++ b/cloud/storage/v1/StorageObjectData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * An object within Google Cloud Storage.

--- a/firebase/analytics/v1/AnalyticsLogData.ts
+++ b/firebase/analytics/v1/AnalyticsLogData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * The data within Firebase Analytics log events.
@@ -42,7 +44,7 @@ export interface EventDim {
     /**
      * A repeated record of the parameters associated with this event.
      */
-    params?: { [key: string]: { [key: string]: any } };
+    params?: { [key: string]: GoogleEventsFirebaseAnalyticsV1AnalyticsValue };
     /**
      * UTC client time when the previous event happened.
      */
@@ -55,6 +57,17 @@ export interface EventDim {
      * Value param in USD.
      */
     valueInUsd?: number;
+}
+
+/**
+ * Value for Event Params and UserProperty can be of type string or int or
+ * float or double.
+ */
+export interface GoogleEventsFirebaseAnalyticsV1AnalyticsValue {
+    doubleValue?: number;
+    floatValue?:  number;
+    intValue?:    number | string;
+    stringValue?: string;
 }
 
 /**
@@ -279,5 +292,27 @@ export interface UserProperty {
     /**
      * Last set value of user property.
      */
-    value?: { [key: string]: any };
+    value?: Value;
 }
+
+/**
+ * Last set value of user property.
+ *
+ * Value for Event Params and UserProperty can be of type string or int or
+ * float or double.
+ */
+export interface Value {
+    doubleValue?: number;
+    floatValue?:  number;
+    intValue?:    number | string;
+    stringValue?: string;
+}
+
+/**
+ * Cast a raw JSON object to a typed event (useful for IDE autocompletion).
+ * @param {object} json The JSON object
+ * @return {AnalyticsLogData} The object with type annotations
+ */
+export const toAnalyticsLogData = (json: object) => {
+  return json as AnalyticsLogData;
+};

--- a/firebase/auth/v1/AuthEventData.ts
+++ b/firebase/auth/v1/AuthEventData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * The data within all Firebase Auth events
@@ -109,3 +111,12 @@ export interface ProviderDatum {
      */
     uid?: string;
 }
+
+/**
+ * Cast a raw JSON object to a typed event (useful for IDE autocompletion).
+ * @param {object} json The JSON object
+ * @return {AuthEventData} The object with type annotations
+ */
+export const toAuthEventData = (json: object) => {
+  return json as AuthEventData;
+};

--- a/firebase/database/v1/ReferenceEventData.ts
+++ b/firebase/database/v1/ReferenceEventData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * The data within all Firebase Real Time Database reference events.
@@ -19,3 +21,12 @@ export interface ReferenceEventData {
     data?:  { [key: string]: any } | null;
     delta?: { [key: string]: any } | null;
 }
+
+/**
+ * Cast a raw JSON object to a typed event (useful for IDE autocompletion).
+ * @param {object} json The JSON object
+ * @return {ReferenceEventData} The object with type annotations
+ */
+export const toReferenceEventData = (json: object) => {
+  return json as ReferenceEventData;
+};

--- a/firebase/remoteconfig/v1/RemoteConfigEventData.ts
+++ b/firebase/remoteconfig/v1/RemoteConfigEventData.ts
@@ -1,16 +1,18 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 /**
  * The data within all Firebase Remote Config events.
@@ -64,3 +66,12 @@ export interface UpdateUser {
      */
     name?: string;
 }
+
+/**
+ * Cast a raw JSON object to a typed event (useful for IDE autocompletion).
+ * @param {object} json The JSON object
+ * @return {RemoteConfigEventData} The object with type annotations
+ */
+export const toRemoteConfigEventData = (json: object) => {
+  return json as RemoteConfigEventData;
+};

--- a/tools/gen.sh
+++ b/tools/gen.sh
@@ -24,4 +24,4 @@ qt \
 
 # Move generated library into correct directory
 cp -a google/events/. .
-rm -r google/events
+rm -r google

--- a/tools/postgen.ts
+++ b/tools/postgen.ts
@@ -19,7 +19,10 @@ const recursive = require("recursive-readdir");
 
 // Wrap in IIFE for top-level await
 (async () => {
-  const filePaths: string[] = await recursive("cloud");
+  const filePaths: string[] = [
+    ...await recursive('cloud'),
+    ...await recursive('firebase')
+  ];
 
   // Get every data type file path
   const dataTsFilePaths = filePaths.filter((path) => {


### PR DESCRIPTION
Runs the generator.

- Uses the updated license header
- Random updates to the types (instead of `{ [key: string]: any };`), which is good.
- Remember to postgen on `firebase` dir. Fixes https://github.com/googleapis/google-cloudevents-nodejs/issues/66