### PR TITLE
Update release-please.yml

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 12
           registry-url: 'https://wombat-dressing-room.appspot.com'
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm ci
+      - run: npm i
         if: ${{ steps.release.outputs.release_created }}
       - run: npm publish
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v1.6.3
+      - uses: GoogleCloudPlatform/release-please-action@v2
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -20,13 +20,33 @@ jobs:
         # a new release is created:
         if: ${{ steps.release.outputs.release_created }}
       - uses: actions/setup-node@v1
+        if: ${{ steps.release.outputs.release_created }}
         with:
           node-version: 12
           registry-url: 'https://wombat-dressing-room.appspot.com'
+      - id: publish
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm i
-        if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.CLOUDEVENTS_NPM_TOKEN}}
+        run: |
+          npm install
+          npm publish
+      - uses: actions/github-script@v3
         if: ${{ steps.release.outputs.release_created }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            await github.issues.addLabels({
+              owner,
+              repo,
+              issue_number: ${{steps.release.outputs.pr}},
+              labels: ['autorelease: published']
+            });
+            github.issues.removeLabel({
+              owner,
+              repo,
+              issue_number: ${{steps.release.outputs.pr}},
+              name: 'autorelease: tagged',
+            });
+            console.log(`Tagged ${{steps.release.outputs.pr}}`)


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloudevents-nodejs/issues/72

Release Please Is failing to publish as we use `npm ci` but don't include a lockfile (which we should not, see Google Node libs).

Error:

```
 npm ci
  shell: /bin/bash -e {0}
  env:
    NPM_CONFIG_USERCONFIG: /home/runner/work/_temp/.npmrc
    NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
npm ERR! cipm can only install packages with an existing package-lock.json or npm-shrinkwrap.json with lockfileVersion >= 1. Run an install with npm@5 or later to generate it, then try again.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-11-06T19_31_00_851Z-debug.log
Error: Process completed with exit code 1.
```