### PR TITLE
build: only label PR if a PR was opened

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,7 @@ jobs:
           package-name: "@google/events"
           command: release-pr
       - id: label
+        if: ${{ steps.release-pr.outputs.pr }}
         uses: actions/github-script@v3
         with:
             github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
If now PR is opened, the action was throwing an error.