### PR TITLE
chore: run the generator, dec 2, 2020

### DIFF
--- a/cloud/audit/v1/LogEntryData.ts
+++ b/cloud/audit/v1/LogEntryData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,10 +15,7 @@
  */
 
 /**
- * Generic log entry, used as a wrapper for Cloud Audit Logs in events.
- * This is copied from
- * https://github.com/googleapis/googleapis/blob/master/google/logging/v2/log_entry.proto
- * and adapted appropriately.
+ * The data within all Cloud Audit Logs log entry events.
  */
 export interface LogEntryData {
     /**
@@ -136,7 +133,7 @@ export interface ProtoPayload {
      * The number of items returned from a List or Query API method,
      * if applicable.
      */
-    numResponseItems?: number | string;
+    numResponseItems?: string;
     /**
      * The operation request. This may not include all request parameters,
      * such as those that are too large, privacy-sensitive, or duplicated
@@ -498,7 +495,7 @@ export interface DestinationAttributes {
     /**
      * The network port of the peer.
      */
-    port?: number | string;
+    port?: string;
     /**
      * The identity of this peer. Similar to `Request.auth.principal`, but
      * relative to the peer instead of the request. For example, the
@@ -578,7 +575,7 @@ export interface RequestAttributes {
     /**
      * The HTTP request size in bytes. If unknown, it must be -1.
      */
-    size?: number | string;
+    size?: string;
     /**
      * The timestamp when the `destination` service receives the first byte of
      * the request.

--- a/cloud/cloudbuild/v1/BuildEventData.ts
+++ b/cloud/cloudbuild/v1/BuildEventData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,11 +15,7 @@
  */
 
 /**
- * Build event data
- * Common build format for Google Cloud Platform API operations.
- * Copied from
- *
- * https://github.com/googleapis/googleapis/blob/master/google/devtools/cloudbuild/v1/cloudbuild.proto.
+ * Build event data for Google Cloud Platform API operations.
  */
 export interface BuildEventData {
     /**
@@ -144,7 +140,7 @@ export interface BuildEventData {
      * If the build does not specify source or images,
      * these keys will not be included.
      */
-    timing?: { [key: string]: GoogleEventsCloudCloudbuildV1TimeSpan };
+    timing?: { [key: string]: TimeSpan };
 }
 
 /**
@@ -241,7 +237,7 @@ export interface Options {
      * requested. At present, the maximum disk size is 1000GB; builds that request
      * more than the maximum are rejected with an error.
      */
-    diskSizeGb?: number | string;
+    diskSizeGb?: string;
     /**
      * A list of global environment variable definitions that will exist for all
      * build steps in this build. If a variable is defined in both globally and in
@@ -296,7 +292,7 @@ export interface Options {
      * Using a global volume in a build with only one step is not valid as
      * it is indicative of a build request with an incorrect configuration.
      */
-    volumes?: GoogleEventsCloudCloudbuildV1Volume[];
+    volumes?: Volume[];
     /**
      * Option to specify a `WorkerPool` for the build.
      * Format: projects/{project}/locations/{location}/workerPools/{workerPool}
@@ -336,7 +332,7 @@ export enum SubstitutionOptionEnum {
  * Volume describes a Docker container volume which is mounted into build steps
  * in order to persist files across build step execution.
  */
-export interface GoogleEventsCloudCloudbuildV1Volume {
+export interface Volume {
     /**
      * Name of the volume to mount.
      *
@@ -375,7 +371,7 @@ export interface QueueTTL {
      * to +315,576,000,000 inclusive. Note: these bounds are computed from:
      * 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
      */
-    seconds?: number | string;
+    seconds?: string;
 }
 
 /**
@@ -411,7 +407,7 @@ export interface Results {
     /**
      * Number of artifacts uploaded. Only populated when artifacts are uploaded.
      */
-    numArtifacts?: number | string;
+    numArtifacts?: string;
 }
 
 /**
@@ -497,11 +493,11 @@ export interface Source {
      * If provided, get the source from this location in a Cloud Source
      * Repository.
      */
-    repoSource?: RepoSource;
+    repoSource?: RepoSourceObject;
     /**
      * If provided, get the source from this location in Google Cloud Storage.
      */
-    storageSource?: StorageSource;
+    storageSource?: StorageSourceObject;
 }
 
 /**
@@ -510,7 +506,7 @@ export interface Source {
  *
  * Location of the source in a Google Cloud Source Repository.
  */
-export interface RepoSource {
+export interface RepoSourceObject {
     /**
      * Regex matching branches to build.
      *
@@ -561,7 +557,7 @@ export interface RepoSource {
  *
  * Location of the source in an archive file in Google Cloud Storage.
  */
-export interface StorageSource {
+export interface StorageSourceObject {
     /**
      * Google Cloud Storage bucket containing the source (see
      * [Bucket Name
@@ -572,7 +568,7 @@ export interface StorageSource {
      * Google Cloud Storage generation for the object. If the generation is
      * omitted, the latest generation will be used.
      */
-    generation?: number | string;
+    generation?: string;
     /**
      * Google Cloud Storage object containing the source.
      */
@@ -709,7 +705,7 @@ export interface ResolvedStorageSourceObject {
      * Google Cloud Storage generation for the object. If the generation is
      * omitted, the latest generation will be used.
      */
-    generation?: number | string;
+    generation?: string;
     /**
      * Google Cloud Storage object containing the source.
      */
@@ -829,7 +825,7 @@ export interface Step {
      * Using a named volume in only one step is not valid as it is indicative
      * of a build request with an incorrect configuration.
      */
-    volumes?: GoogleEventsCloudCloudbuildV1Volume[];
+    volumes?: Volume[];
     /**
      * The ID(s) of the step(s) that this build step depends on.
      * This build step will not start until all the build steps in `wait_for`
@@ -879,7 +875,7 @@ export interface StepTimeout {
      * to +315,576,000,000 inclusive. Note: these bounds are computed from:
      * 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
      */
-    seconds?: number | string;
+    seconds?: string;
 }
 
 /**
@@ -920,7 +916,7 @@ export interface BuildEventDataTimeout {
      * to +315,576,000,000 inclusive. Note: these bounds are computed from:
      * 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
      */
-    seconds?: number | string;
+    seconds?: string;
 }
 
 /**
@@ -928,7 +924,7 @@ export interface BuildEventDataTimeout {
  *
  * Start and end times for a build execution phase.
  */
-export interface GoogleEventsCloudCloudbuildV1TimeSpan {
+export interface TimeSpan {
     /**
      * End of time span.
      */

--- a/cloud/firestore/v1/DocumentEventData.ts
+++ b/cloud/firestore/v1/DocumentEventData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,7 +125,7 @@ export interface OldValueField {
     /**
      * An integer value.
      */
-    integerValue?: number | string;
+    integerValue?: string;
     /**
      * A map value.
      */
@@ -189,7 +189,7 @@ export interface MapValueField {
     /**
      * An integer value.
      */
-    integerValue?: number | string;
+    integerValue?: string;
     /**
      * A map value.
      */
@@ -268,7 +268,7 @@ export interface ValueElement {
     /**
      * An integer value.
      */
-    integerValue?: number | string;
+    integerValue?: string;
     /**
      * A map value.
      */

--- a/cloud/pubsub/v1/MessagePublishedData.ts
+++ b/cloud/pubsub/v1/MessagePublishedData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 
 /**
- * The data received in an event when a message is published to a topic.
+ * The event data when a message is published to a topic.
  */
 export interface MessagePublishedData {
     /**

--- a/cloud/scheduler/v1/SchedulerJobData.ts
+++ b/cloud/scheduler/v1/SchedulerJobData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/cloud/storage/v1/StorageObjectData.ts
+++ b/cloud/storage/v1/StorageObjectData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -80,7 +80,7 @@ export interface StorageObjectData {
      * The content generation of this object. Used for object versioning.
      * Attempting to set this field will result in an error.
      */
-    generation?: number | string;
+    generation?: string;
     /**
      * The ID of the object, including the bucket name, object name, and
      * generation number.
@@ -117,7 +117,7 @@ export interface StorageObjectData {
      * number is only meaningful in the context of a particular generation of a
      * particular object.
      */
-    metageneration?: number | string;
+    metageneration?: string;
     /**
      * The name of the object.
      */
@@ -135,7 +135,7 @@ export interface StorageObjectData {
      * Content-Length of the object data in bytes, matching
      * [https://tools.ietf.org/html/rfc7230#section-3.3.2][RFC 7230 §3.3.2].
      */
-    size?: number | string;
+    size?: string;
     /**
      * Storage class of the object.
      */

--- a/firebase/analytics/v1/AnalyticsLogData.ts
+++ b/firebase/analytics/v1/AnalyticsLogData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -44,15 +44,15 @@ export interface EventDim {
     /**
      * A repeated record of the parameters associated with this event.
      */
-    params?: { [key: string]: GoogleEventsFirebaseAnalyticsV1AnalyticsValue };
+    params?: { [key: string]: AnalyticsValue };
     /**
      * UTC client time when the previous event happened.
      */
-    previousTimestampMicros?: number | string;
+    previousTimestampMicros?: string;
     /**
      * UTC client time when the event happened.
      */
-    timestampMicros?: number | string;
+    timestampMicros?: string;
     /**
      * Value param in USD.
      */
@@ -63,10 +63,10 @@ export interface EventDim {
  * Value for Event Params and UserProperty can be of type string or int or
  * float or double.
  */
-export interface GoogleEventsFirebaseAnalyticsV1AnalyticsValue {
+export interface AnalyticsValue {
     doubleValue?: number;
     floatValue?:  number;
-    intValue?:    number | string;
+    intValue?:    string;
     stringValue?: string;
 }
 
@@ -89,7 +89,7 @@ export interface UserDim {
     /**
      * The time (in microseconds) at which the user first opened the app.
      */
-    firstOpenTimestampMicros?: number | string;
+    firstOpenTimestampMicros?: string;
     /**
      * User's geographic information.
      */
@@ -155,7 +155,7 @@ export interface BundleInfo {
     /**
      * Timestamp offset between collection time and upload time.
      */
-    serverTimestampOffsetMicros?: number | string;
+    serverTimestampOffsetMicros?: string;
 }
 
 /**
@@ -288,7 +288,7 @@ export interface UserProperty {
     /**
      * UTC client time when user property was last set.
      */
-    setTimestampUsec?: number | string;
+    setTimestampUsec?: string;
     /**
      * Last set value of user property.
      */
@@ -304,7 +304,7 @@ export interface UserProperty {
 export interface Value {
     doubleValue?: number;
     floatValue?:  number;
-    intValue?:    number | string;
+    intValue?:    string;
     stringValue?: string;
 }
 

--- a/firebase/auth/v1/AuthEventData.ts
+++ b/firebase/auth/v1/AuthEventData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,7 +15,7 @@
  */
 
 /**
- * The data within all Firebase Auth events
+ * The data within all Firebase Auth events.
  */
 export interface AuthEventData {
     /**

--- a/firebase/database/v1/ReferenceEventData.ts
+++ b/firebase/database/v1/ReferenceEventData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/firebase/remoteconfig/v1/RemoteConfigEventData.ts
+++ b/firebase/remoteconfig/v1/RemoteConfigEventData.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -26,7 +26,7 @@ export interface RemoteConfigEventData {
      * Only present if this version is the result of a rollback, and will be the
      * version number of the Remote Config template that was rolled-back to.
      */
-    rollbackSource?: number | string;
+    rollbackSource?: string;
     /**
      * Where the update action originated.
      */
@@ -46,7 +46,7 @@ export interface RemoteConfigEventData {
     /**
      * The version number of the version's corresponding Remote Config template.
      */
-    versionNumber?: number | string;
+    versionNumber?: string;
 }
 
 /**


### PR DESCRIPTION
Re-runs the generator.

- Updates headers
- Uses string type for 64 bit numbers (uses updated jsonschemas). See https://developers.google.com/protocol-buffers/docs/proto3#json
- Not exactly sure why the longer terms were lingering from before, but shortens longer terms like `GoogleEventsCloudCloudbuildV1TimeSpan`.

Uses these PRs:

- https://github.com/googleapis/google-cloudevents/pull/123
- https://github.com/googleapis/google-cloudevents/pull/104