### PR TITLE
fix: fix the build release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -56,6 +56,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.CLOUDEVENTS_NPM_TOKEN}}
         run: |
           npm install
+          npm run build
           npm publish
       - uses: actions/github-script@v3
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
It looks like the TypeScript project wasn't and currently isn't being built before being published. This is resulting in the module not working.

This change runs the build step before publishing the module.

Fixes https://github.com/googleapis/google-cloudevents-nodejs/issues/80