### PR TITLE
fix!: allow date types to be strings | re-runs the generator

### DIFF
--- a/cloud/audit/v1/LogEntryData.ts
+++ b/cloud/audit/v1/LogEntryData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,17 +32,19 @@ export interface LogEntryData {
      */
     logName?: string;
     /**
-     * Information about an operation associated with the log entry, if applicable.
+     * Information about an operation associated with the log entry, if
+     * applicable.
      */
     operation?: Operation;
     /**
-     * The log entry payload, which is always an AuditLog for Cloud Audit Log events.
+     * The log entry payload, which is always an AuditLog for Cloud Audit Log
+     * events.
      */
     protoPayload?: ProtoPayload;
     /**
      * The time the log entry was received by Logging.
      */
-    receiveTimestamp?: Date;
+    receiveTimestamp?: Date | string;
     /**
      * The monitored resource that produced this log entry.
      *
@@ -66,7 +68,7 @@ export interface LogEntryData {
     /**
      * The time the event described by the log entry occurred.
      */
-    timestamp?: Date;
+    timestamp?: Date | string;
     /**
      * Resource name of the trace associated with the log entry, if any. If it
      * contains a relative resource name, the name is assumed to be relative to
@@ -77,7 +79,8 @@ export interface LogEntryData {
 }
 
 /**
- * Information about an operation associated with the log entry, if applicable.
+ * Information about an operation associated with the log entry, if
+ * applicable.
  */
 export interface Operation {
     /**
@@ -102,7 +105,8 @@ export interface Operation {
 }
 
 /**
- * The log entry payload, which is always an AuditLog for Cloud Audit Log events.
+ * The log entry payload, which is always an AuditLog for Cloud Audit Log
+ * events.
  */
 export interface ProtoPayload {
     /**
@@ -180,7 +184,7 @@ export interface ProtoPayload {
      */
     response?: Response;
     /**
-     * Deprecated, use `metadata` field instead.
+     * Deprecated: Use `metadata` field instead.
      * Other service-specific data about the request, response, and other
      * activities.
      * When the JSON object represented here has a proto equivalent, the proto
@@ -580,7 +584,7 @@ export interface RequestAttributes {
      * The timestamp when the `destination` service receives the first byte of
      * the request.
      */
-    time?: Date;
+    time?: Date | string;
 }
 
 /**
@@ -734,7 +738,7 @@ export interface Response {
 }
 
 /**
- * Deprecated, use `metadata` field instead.
+ * Deprecated: Use `metadata` field instead.
  * Other service-specific data about the request, response, and other
  * activities.
  * When the JSON object represented here has a proto equivalent, the proto

--- a/cloud/cloudbuild/v1/BuildEventData.ts
+++ b/cloud/cloudbuild/v1/BuildEventData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,14 +31,14 @@ export interface BuildEventData {
     /**
      * Time at which the request to create the build was received.
      */
-    createTime?: Date;
+    createTime?: Date | string;
     /**
      * Time at which execution of the build was finished.
      *
      * The difference between finish_time and start_time is the duration of the
      * build's execution.
      */
-    finishTime?: Date;
+    finishTime?: Date | string;
     /**
      * Unique identifier of the build.
      */
@@ -102,7 +102,7 @@ export interface BuildEventData {
     /**
      * Time at which execution of the build was started.
      */
-    startTime?: Date;
+    startTime?: Date | string;
     /**
      * Status of the build.
      */
@@ -218,11 +218,11 @@ export interface ObjectsTiming {
     /**
      * End of time span.
      */
-    endTime?: Date;
+    endTime?: Date | string;
     /**
      * Start of time span.
      */
-    startTime?: Date;
+    startTime?: Date | string;
 }
 
 /**
@@ -427,11 +427,11 @@ export interface ArtifactTiming {
     /**
      * End of time span.
      */
-    endTime?: Date;
+    endTime?: Date | string;
     /**
      * Start of time span.
      */
-    startTime?: Date;
+    startTime?: Date | string;
 }
 
 /**
@@ -464,11 +464,11 @@ export interface PushTiming {
     /**
      * End of time span.
      */
-    endTime?: Date;
+    endTime?: Date | string;
     /**
      * Start of time span.
      */
-    startTime?: Date;
+    startTime?: Date | string;
 }
 
 /**
@@ -848,11 +848,11 @@ export interface PullTiming {
     /**
      * End of time span.
      */
-    endTime?: Date;
+    endTime?: Date | string;
     /**
      * Start of time span.
      */
-    startTime?: Date;
+    startTime?: Date | string;
 }
 
 /**
@@ -889,11 +889,11 @@ export interface StepTiming {
     /**
      * End of time span.
      */
-    endTime?: Date;
+    endTime?: Date | string;
     /**
      * Start of time span.
      */
-    startTime?: Date;
+    startTime?: Date | string;
 }
 
 /**
@@ -928,11 +928,11 @@ export interface TimeSpan {
     /**
      * End of time span.
      */
-    endTime?: Date;
+    endTime?: Date | string;
     /**
      * Start of time span.
      */
-    startTime?: Date;
+    startTime?: Date | string;
 }
 
 /**

--- a/cloud/firestore/v1/DocumentEventData.ts
+++ b/cloud/firestore/v1/DocumentEventData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ export interface OldValue {
      * recreated. It can also be compared to values from other documents and
      * the `read_time` of a query.
      */
-    createTime?: Date;
+    createTime?: Date | string;
     /**
      * The document's fields.
      *
@@ -78,8 +78,8 @@ export interface OldValue {
      */
     fields?: { [key: string]: OldValueField };
     /**
-     * The resource name of the document, for example
-     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     * The resource name of the document. For example:
+     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`
      */
     name?: string;
     /**
@@ -89,7 +89,7 @@ export interface OldValue {
      * monotonically with each change to the document. It can also be
      * compared to values from other documents and the `read_time` of a query.
      */
-    updateTime?: Date;
+    updateTime?: Date | string;
 }
 
 /**
@@ -153,7 +153,7 @@ export interface OldValueField {
      * Precise only to microseconds. When stored, any additional precision is
      * rounded down.
      */
-    timestampValue?: Date;
+    timestampValue?: Date | string;
 }
 
 /**
@@ -217,7 +217,7 @@ export interface MapValueField {
      * Precise only to microseconds. When stored, any additional precision is
      * rounded down.
      */
-    timestampValue?: Date;
+    timestampValue?: Date | string;
 }
 
 /**
@@ -296,7 +296,7 @@ export interface ValueElement {
      * Precise only to microseconds. When stored, any additional precision is
      * rounded down.
      */
-    timestampValue?: Date;
+    timestampValue?: Date | string;
 }
 
 /**
@@ -360,7 +360,7 @@ export interface Value {
      * recreated. It can also be compared to values from other documents and
      * the `read_time` of a query.
      */
-    createTime?: Date;
+    createTime?: Date | string;
     /**
      * The document's fields.
      *
@@ -389,8 +389,8 @@ export interface Value {
      */
     fields?: { [key: string]: OldValueField };
     /**
-     * The resource name of the document, for example
-     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
+     * The resource name of the document. For example:
+     * `projects/{project_id}/databases/{database_id}/documents/{document_path}`
      */
     name?: string;
     /**
@@ -400,7 +400,7 @@ export interface Value {
      * monotonically with each change to the document. It can also be
      * compared to values from other documents and the `read_time` of a query.
      */
-    updateTime?: Date;
+    updateTime?: Date | string;
 }
 
 /**

--- a/cloud/pubsub/v1/MessagePublishedData.ts
+++ b/cloud/pubsub/v1/MessagePublishedData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,16 @@ export interface Message {
      * Guaranteed to be unique within the topic.
      */
     messageId?: string;
+    /**
+     * If non-empty, identifies related messages for which publish order should be
+     * respected.
+     */
+    orderingKey?: string;
+    /**
+     * The time at which the message was published, populated by the server when
+     * it receives the `Publish` call.
+     */
+    publishTime?: Date | string;
 }
 
 /**

--- a/cloud/scheduler/v1/SchedulerJobData.ts
+++ b/cloud/scheduler/v1/SchedulerJobData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cloud/storage/v1/StorageObjectData.ts
+++ b/cloud/storage/v1/StorageObjectData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ export interface StorageObjectData {
      * [https://cloud.google.com/storage/docs/hashes-etags#_JSONAPI][Hashes and
      * ETags: Best Practices].
      */
-    crc32C?: string;
+    crc32c?: string;
     /**
      * Metadata of customer-supplied encryption key, if the object is encrypted by
      * such a key.
@@ -126,7 +126,7 @@ export interface StorageObjectData {
      * A server-determined value that specifies the earliest time that the
      * object's retention period expires.
      */
-    retentionExpirationTime?: Date;
+    retentionExpirationTime?: Date | string;
     /**
      * The link to this object.
      */
@@ -148,20 +148,20 @@ export interface StorageObjectData {
      * The creation time of the object.
      * Attempting to set this field will result in an error.
      */
-    timeCreated?: Date;
+    timeCreated?: Date | string;
     /**
      * The deletion time of the object. Will be returned if and only if this
      * version of the object has been deleted.
      */
-    timeDeleted?: Date;
+    timeDeleted?: Date | string;
     /**
      * The time at which the object's storage class was last changed.
      */
-    timeStorageClassUpdated?: Date;
+    timeStorageClassUpdated?: Date | string;
     /**
      * The modification time of the object metadata.
      */
-    updated?: Date;
+    updated?: Date | string;
 }
 
 /**

--- a/firebase/analytics/v1/AnalyticsLogData.ts
+++ b/firebase/analytics/v1/AnalyticsLogData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/firebase/auth/v1/AuthEventData.ts
+++ b/firebase/auth/v1/AuthEventData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ export interface AuthEventData {
     /**
      * The user's photo URL.
      */
-    photoUrl?: string;
+    photoURL?: string;
     /**
      * User's info at the providers
      */
@@ -79,11 +79,11 @@ export interface Metadata {
     /**
      * The date the user was created.
      */
-    createdAt?: Date;
+    createTime?: Date | string;
     /**
      * The date the user last signed in.
      */
-    lastSignedInAt?: Date;
+    lastSignInTime?: Date | string;
 }
 
 /**
@@ -101,7 +101,7 @@ export interface ProviderDatum {
     /**
      * The photo URL for the linked provider.
      */
-    photoUrl?: string;
+    photoURL?: string;
     /**
      * The linked provider ID (e.g. "google.com" for the Google provider).
      */

--- a/firebase/database/v1/ReferenceEventData.ts
+++ b/firebase/database/v1/ReferenceEventData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/firebase/remoteconfig/v1/RemoteConfigEventData.ts
+++ b/firebase/remoteconfig/v1/RemoteConfigEventData.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,13 +34,14 @@ export interface RemoteConfigEventData {
     /**
      * When the Remote Config template was written to the Remote Config server.
      */
-    updateTime?: Date;
+    updateTime?: Date | string;
     /**
      * What type of update was made.
      */
     updateType?: UpdateTypeEnum | number;
     /**
-     * Aggregation of all metadata fields about the account that performed the update.
+     * Aggregation of all metadata fields about the account that performed the
+     * update.
      */
     updateUser?: UpdateUser;
     /**
@@ -64,7 +65,8 @@ export enum UpdateTypeEnum {
 }
 
 /**
- * Aggregation of all metadata fields about the account that performed the update.
+ * Aggregation of all metadata fields about the account that performed the
+ * update.
  */
 export interface UpdateUser {
     /**

--- a/tools/postgen.ts
+++ b/tools/postgen.ts
@@ -37,9 +37,15 @@ const recursive = require("recursive-readdir");
     const typeFileContent = fs.readFileSync(filename).toString();
 
     // Get TS interfaces
-    const lines = typeFileContent.split('\n');
+    let lines = typeFileContent.split('\n');
     const interfaceLines = lines.filter((line) => {
       return line.startsWith('export interface');
+    });
+
+    // Allow TS Date types to be strings
+    lines = lines.map((l: string) => {
+      if (l.includes('Date;')) console.log(l);
+      return l.replace('Date;', 'Date | string;');
     });
 
     // The data name, e.g. 'export interface MessagePublishedData {'
@@ -47,7 +53,7 @@ const recursive = require("recursive-readdir");
         .split(' ')
         .filter((token) => token.endsWith('Data'))[0];
 
-    const newTypeFileContent = typeFileContent + `
+    const newTypeFileContent = lines.join('\n') + `
 /**
  * Cast a raw JSON object to a typed event (useful for IDE autocompletion).
  * @param {object} json The JSON object


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloudevents-nodejs/issues/91

- Allows Google CloudEvent date types to be either a JS **date** object **or a string**. (APIs return strings)
- Re-runs the generator (includes very minor breaking changes with TS field capitalization). The generator has not been run in a few months.