### PR TITLE
feat: improve types for protobuf duration fields

### DIFF
--- a/cloud/audit/v1/LogEntryData.ts
+++ b/cloud/audit/v1/LogEntryData.ts
@@ -283,7 +283,9 @@ export interface ServiceMetadata {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**
@@ -303,7 +305,9 @@ export interface ThirdPartyClaims {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**
@@ -316,7 +320,9 @@ export interface AuthenticationInfoThirdPartyPrincipal {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**
@@ -401,7 +407,9 @@ export interface Metadata {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**
@@ -416,7 +424,9 @@ export interface Request {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**
@@ -675,7 +685,9 @@ export interface Claims {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**
@@ -719,7 +731,9 @@ export interface ResourceOriginalState {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**
@@ -734,7 +748,9 @@ export interface Response {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**
@@ -748,7 +764,9 @@ export interface ServiceData {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**

--- a/cloud/cloudbuild/v1/BuildEventData.ts
+++ b/cloud/cloudbuild/v1/BuildEventData.ts
@@ -82,7 +82,7 @@ export interface BuildEventData {
    *
    * The TTL starts ticking from create_time.
    */
-  queueTtl?: QueueTTL;
+  queueTtl?: string;
   /**
    * Results of the build.
    */
@@ -128,7 +128,7 @@ export interface BuildEventData {
    * granularity. If this amount of time elapses, work on the build will cease
    * and the build status will be `TIMEOUT`.
    */
-  timeout?: BuildEventDataTimeout;
+  timeout?: string;
   /**
    * Stores timing information for phases of the build. Valid keys
    * are:
@@ -353,31 +353,6 @@ export interface Volume {
    * same build step or with certain reserved volume paths.
    */
   path?: string;
-}
-
-/**
- * TTL in queue for this build. If provided and the build is enqueued longer
- * than this value, the build will expire and the build status will be
- * `EXPIRED`.
- *
- * The TTL starts ticking from create_time.
- */
-export interface QueueTTL {
-  /**
-   * Signed fractions of a second at nanosecond resolution of the span
-   * of time. Durations less than one second are represented with a 0
-   * `seconds` field and a positive or negative `nanos` field. For durations
-   * of one second or more, a non-zero value for the `nanos` field must be
-   * of the same sign as the `seconds` field. Must be from -999,999,999
-   * to +999,999,999 inclusive.
-   */
-  nanos?: number;
-  /**
-   * Signed seconds of the span of time. Must be from -315,576,000,000
-   * to +315,576,000,000 inclusive. Note: these bounds are computed from:
-   * 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
-   */
-  seconds?: number;
 }
 
 /**
@@ -810,7 +785,7 @@ export interface Step {
    * time limit and will be allowed to continue to run until either it completes
    * or the build itself times out.
    */
-  timeout?: StepTimeout;
+  timeout?: string;
   /**
    * Stores timing information for executing this build step.
    */
@@ -856,29 +831,6 @@ export interface PullTiming {
 }
 
 /**
- * Time limit for executing this build step. If not defined, the step has no
- * time limit and will be allowed to continue to run until either it completes
- * or the build itself times out.
- */
-export interface StepTimeout {
-  /**
-   * Signed fractions of a second at nanosecond resolution of the span
-   * of time. Durations less than one second are represented with a 0
-   * `seconds` field and a positive or negative `nanos` field. For durations
-   * of one second or more, a non-zero value for the `nanos` field must be
-   * of the same sign as the `seconds` field. Must be from -999,999,999
-   * to +999,999,999 inclusive.
-   */
-  nanos?: number;
-  /**
-   * Signed seconds of the span of time. Must be from -315,576,000,000
-   * to +315,576,000,000 inclusive. Note: these bounds are computed from:
-   * 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
-   */
-  seconds?: number;
-}
-
-/**
  * Stores timing information for executing this build step.
  *
  * Stores timing information for pushing all artifact objects.
@@ -894,29 +846,6 @@ export interface StepTiming {
    * Start of time span.
    */
   startTime?: Date | string;
-}
-
-/**
- * Amount of time that this build should be allowed to run, to second
- * granularity. If this amount of time elapses, work on the build will cease
- * and the build status will be `TIMEOUT`.
- */
-export interface BuildEventDataTimeout {
-  /**
-   * Signed fractions of a second at nanosecond resolution of the span
-   * of time. Durations less than one second are represented with a 0
-   * `seconds` field and a positive or negative `nanos` field. For durations
-   * of one second or more, a non-zero value for the `nanos` field must be
-   * of the same sign as the `seconds` field. Must be from -999,999,999
-   * to +999,999,999 inclusive.
-   */
-  nanos?: number;
-  /**
-   * Signed seconds of the span of time. Must be from -315,576,000,000
-   * to +315,576,000,000 inclusive. Note: these bounds are computed from:
-   * 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
-   */
-  seconds?: number;
 }
 
 /**

--- a/cloud/firestore/v1/DocumentEventData.ts
+++ b/cloud/firestore/v1/DocumentEventData.ts
@@ -30,7 +30,7 @@ export interface DocumentEventData {
   updateMask?: UpdateMask;
   /**
    * A Document object containing a post-operation document snapshot.
-   * This is not populated for delete events. (TODO: check this!)
+   * This is not populated for delete events.
    */
   value?: Value;
 }

--- a/firebase/auth/v1/AuthEventData.ts
+++ b/firebase/auth/v1/AuthEventData.ts
@@ -69,7 +69,9 @@ export interface CustomClaims {
   /**
    * Unordered map of dynamically typed values.
    */
-  fields?: {[key: string]: {[key: string]: any}};
+  fields?: {
+    [key: string]: any[] | boolean | number | {[key: string]: any} | string;
+  };
 }
 
 /**

--- a/firebase/database/v1/ReferenceEventData.ts
+++ b/firebase/database/v1/ReferenceEventData.ts
@@ -18,14 +18,8 @@
  * The data within all Firebase Real Time Database reference events.
  */
 export interface ReferenceEventData {
-  /**
-   * The original data for the reference.
-   */
-  data?: {[key: string]: any};
-  /**
-   * The change in the reference data.
-   */
-  delta?: {[key: string]: any};
+  data?: any[] | boolean | number | {[key: string]: any} | string;
+  delta?: any[] | boolean | number | {[key: string]: any} | string;
 }
 
 /**


### PR DESCRIPTION
Generation from updated schemas: https://github.com/googleapis/google-cloudevents/pull/254

Should allow proper typing for Cloud Build types for example.